### PR TITLE
Do not skip everything in _createNativeAnimation nativeView.layer is …

### DIFF
--- a/packages/core/ui/animation/index.ios.ts
+++ b/packages/core/ui/animation/index.ios.ts
@@ -439,7 +439,7 @@ export class Animation extends AnimationBase {
 
 	private static _createNativeAnimation(propertyAnimations: Array<PropertyAnimation>, index: number, playSequentially: boolean, args: AnimationInfo, animation: PropertyAnimation, valueSource: 'animation' | 'keyframe', finishedCallback: (cancelled?: boolean) => void) {
 		const nativeView = <UIView>animation.target.nativeViewProtected;
-		if (nativeView?.layer) {
+		
 			let nativeAnimation;
 
 			if (args.subPropertiesToAnimate) {
@@ -450,9 +450,11 @@ export class Animation extends AnimationBase {
 
 			const animationDelegate = AnimationDelegateImpl.initWithFinishedCallback(finishedCallback, animation, valueSource);
 			nativeAnimation.setValueForKey(animationDelegate, 'delegate');
-
-			nativeView.layer.addAnimationForKey(nativeAnimation, args.propertyNameToAnimate);
-
+			
+		  if (nativeView?.layer) {
+				nativeView.layer.addAnimationForKey(nativeAnimation, args.propertyNameToAnimate);
+			}
+		
 			let callback = undefined;
 			if (index + 1 < propertyAnimations.length) {
 				callback = Animation._createiOSAnimationFunction(propertyAnimations, index + 1, playSequentially, valueSource, finishedCallback);
@@ -462,7 +464,7 @@ export class Animation extends AnimationBase {
 					animationDelegate.nextAnimation = callback;
 				}
 			}
-		}
+		
 	}
 
 	private static _createGroupAnimation(args: AnimationInfo, animation: PropertyAnimation) {


### PR DESCRIPTION
…undefined

At least in some if not all cases (noted with ui-drawer), the layer will be undefined when `_createNativeAnimation` is called. All of the logic in this method was contained within the `if (nativeView?.layer) { }`.  However, the animation still needs the rest of the logic in this method. I found this by noting that the `_createNativeSpringAnimation` would work when the `_createNativeAnimation` would not work, and that the spring version of the animation does not care if the layer is undefined.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/DevelopmentWorkflow.md#running-unit-tests-application.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/tools/notes/WritingUnitTests.md.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

